### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a bug.
+
+---
+
+<!--
+Thank you for submitting this bug report!
+
+If your issue relates to using the OpenFF Toolkit (loading molecules or
+topologies, applying force fields, using the AmberTools/RDKit/OpenEye toolkit
+wrappers), compatibilities with conversions through OpenMM/ParmEd, or
+installing software, please raise an issue in the OpenFF Toolkit repo:
+
+https://github.com/openforcefield/openff-toolkit/issues/new/choose
+
+If your issue relates more specifically to the force fields themselves (missing
+or seemingly bad parameters, force fields producing bad physics or blowing up),
+please continue below.
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior. A minimal reproducing set of python commands is ideal.
+
+If the problem involves a specific molecule or file, please upload that as well.
+
+**Output**
+The full error message (may be large, that's fine. Better to paste too much than too little.)
+
+**Computing environment (please complete the following information):**
+ - Operating system
+ - Output of running `conda list` 
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+Thank you for submitting this feature request!
+
+If your proposal relates to using the OpenFF Toolkit (loading molecules or
+topologies, applying force fields, using the AmberTools/RDKit/OpenEye toolkit
+wrappers), compatibilities with conversions through OpenMM/ParmEd, or
+installing software, please raise an issue in the OpenFF Toolkit repo:
+
+https://github.com/openforcefield/openff-toolkit/issues/new/choose
+
+If your idea relates more specifically to the force fields themselves and their contents, please continue below.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This repo is a reasonable landing spot for users to raise issues, but there are no issue templates to guide users to creating details bug reports. In some cases it may be useful to direct users to the toolkit (or other projects/docs/FAQ). This PR adds issue templates for bug reports and feature requests. They are mostly copied from the toolkit's templates.