### PR TITLE
Simplify .zenodo.json since zenodo complained and didn't make a doi

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -52,26 +52,8 @@
       }
     ],
     "access_right": "open",
-    "resource_type": {
-      "type": "software",
-      "title": "Software"
-    },
-    "related_identifiers": [
-      {
-        "scheme": "doi",
-        "identifier": "10.5281/zenodo.5214478",
-        "relation": "isVersionOf"
-      }
-    ],
-
     "license": "CC-BY-4.0",
     "title": "openforcefield/openff-forcefields",
-
-    "communities": [
-      {
-        "id": "openforcefield"
-      }
-    ],
     "keywords": [
       "force field",
       "molecular dynamics",


### PR DESCRIPTION
Zenodo said the following when failing to make a DOI for 2023.04.1:

```
{
    "errors": "{'metadata': {'communities': [u\"Invalid community format: [{u'id': u'openforcefield'}].\"], u'resource_type': [u'Unknown field name.'], 'related_identifiers': {0: {'relation': [u'Not a valid choice.']}}}}"
}
```

So we've removed the things that we think it was complaining about, as well as some others. There's technically a sandbox zenodo where we can suss this out but since we'll be making a series of RCs this month I think it's fine if we just figure this out in prod. 