### PR TITLE
Skip sigma comparion when epsilons are both zero

### DIFF
--- a/openforcefields/tests/compare.py
+++ b/openforcefields/tests/compare.py
@@ -53,7 +53,7 @@ def _compare_nonbonded_forces(
 
         # Water models commonly have zero epsilon and meaningless/inconsistent values
         # of sigma. In this case, do not compare sigma values.
-        if epsilon1._value * epsilon1._value != 0.0:
+        if epsilon1._value * epsilon2._value != 0.0:
             assert (
                 abs(sigma1 - sigma2) < tolerances["sigma"]
             ), f"{sigma1} != {sigma2}, {sigma1 - sigma2}"

--- a/openforcefields/tests/compare.py
+++ b/openforcefields/tests/compare.py
@@ -50,9 +50,14 @@ def _compare_nonbonded_forces(
         assert (
             abs(charge1 - charge2) < tolerances["charge"]
         ), f"{charge1} != {charge2}, {charge1 - charge2}"
-        assert (
-            abs(sigma1 - sigma2) < tolerances["sigma"]
-        ), f"{sigma1} != {sigma2}, {sigma1 - sigma2}"
+
+        # Water models commonly have zero epsilon and meaningless/inconsistent values
+        # of sigma. In this case, do not compare sigma values.
+        if epsilon1._value * epsilon1._value != 0.0:
+            assert (
+                abs(sigma1 - sigma2) < tolerances["sigma"]
+            ), f"{sigma1} != {sigma2}, {sigma1 - sigma2}"
+
         assert (
             abs(epsilon1 - epsilon2) < tolerances["epsilon"]
         ), f"{epsilon1} != {epsilon2}, {epsilon1 - epsilon2}"

--- a/openforcefields/tests/test_water_models.py
+++ b/openforcefields/tests/test_water_models.py
@@ -7,7 +7,6 @@ from openff.interchange.interop.openmm import to_openmm_topology
 from openff.toolkit import ForceField, Molecule, Topology
 from openmm.app import ForceField as OpenMMForceField
 from openmm.app import HAngles
-from openmm.app import Topology as OpenMMTopology
 
 from openforcefields.tests.compare import _compare
 
@@ -91,8 +90,6 @@ def test_tip3p_fb(water_molecule):
         },
     )
 
-# TODO: The interchange that results from applying the OPC water model yields a sigma that is exactly
-#  twice what it should be on the hydrogens. This problem is only cosmetic as the epsilon is 0.
 def test_opc(water_molecule):
     from openmm.app import Modeller
     omm_water = water_molecule.to_openmm()
@@ -109,16 +106,19 @@ def test_opc(water_molecule):
         water_molecule,
     )
     system = interchange.to_openmm()
+
+    # OpenMM's `opc.xml` has inaccurate values of sigma for H and M. Since both
+    # have zero epsilon, logic in this comparison function skips them.
     compare_water_systems(
         reference,
         system,
         {
             "charge": 1e-10 * openmm.unit.elementary_charge,
-            #"sigma": 1e-10 * openmm.unit.nanometer,
-            "sigma": .1 * openmm.unit.nanometer,
+            "sigma": 1e-10 * openmm.unit.nanometer,
             "epsilon": 1e-10 * openmm.unit.kilojoule_per_mole,
         },
     )
+
 
 @pytest.mark.skip(reason="Skipping in first pass")
 def test_tip4p_ew(water_molecule):


### PR DESCRIPTION
This removes a stray TODO from #65, which includes the context for this change.