### PR TITLE
Remove use of `pkg_resources`

### DIFF
--- a/openforcefields/openforcefields.py
+++ b/openforcefields/openforcefields.py
@@ -1,18 +1,15 @@
 """
 openforcefields.py
-A general small molecule forcefield descended from AMBER99 and parm@Frosst in the SMIRNOFF format.
 
 This module only contains the function that will be the entry point that
 will be used by the openforcefield toolkit to find the installed forcefield
 files.
 
 """
-from typing import List
-
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 
-def get_forcefield_dirs_paths() -> List[str]:
+def get_forcefield_dirs_paths() -> list[str]:
     """
     Return the paths to the directories including the forcefield files.
 
@@ -22,10 +19,8 @@ def get_forcefield_dirs_paths() -> List[str]:
 
     Returns
     -------
-    dir_paths : List[str]
+    dir_paths : list[str]
         The list of directory paths containing the SMIRNOFF files.
 
     """
-    return [
-        resource_filename('openforcefields', 'offxml'),
-    ]
+    return [(files("openforcefields") / "offxml").as_posix()]


### PR DESCRIPTION
This basically ports a stripped-down version of the same functionality in `openff-utilities`, but without bring it in.

https://github.com/openforcefield/openff-utilities/blob/87fe0338d4c2c86a3a08c2deb4e151239c148a0c/openff/utilities/utilities.py#L190-L232